### PR TITLE
Change `bye()` to exit with failure

### DIFF
--- a/koe-root.sh
+++ b/koe-root.sh
@@ -2,7 +2,7 @@
 
 function bye(){
 	echo $@
-	exit
+	exit 1
 }
 
 keysign=koe-6387871410@local


### PR DESCRIPTION
`man exit` shows

```
EXAMPLES
       Exit with a true value:

           exit 0

       Exit with a false value:

           exit 1
```

and this bye represents failure, so I believe it's nicer if it uses `exit 1` instead there.